### PR TITLE
Use probability to make predictions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,9 +23,18 @@ function updateModelF (fivegram) {
   }
 }
 
+function getProbability (target, complement) {
+  var total = target + complement
+  // never divide by zero
+  if (total === 0)
+    return 1 / 2
+  return target / total
+}
+
 function predictNextLetter (fivegram) {
   var m = model[fivegram]
-  if (m.f > m.d)
+  var p = getProbability(m.f, m.d)
+  if (p > Math.random())
     return 'f'
   return 'd'
 }


### PR DESCRIPTION
This PR makes two changes:
- A random prediction is made when `m.f` and `m.d` are equal (resolves #4)
- A probabilistic prediction is made when `m.f` and `m.d` are unequal (resolves #5)

It's now *very* improbable for "malicious" patterns like `dddddffffffdffffddfffdfdfffdddff` to hit 0%. I ran the new algorithm against the above pattern, and these were my results:

n | p
---|---
1 | 33% 
2 | 29%
3 | 40%
4 | 37%
5 | 44%
6 | 40%
7 | 37%
8 | 44%
9 | 29%
10 | 40%
11 | 11%
12 | 40%
13 | 29%
14 | 37%
15 | 18%
16 | 33%
**mean** | 34%

It definitely isn't perfect, but a mean of 34% is a step up from 0%. It seems to work well with `npm test`, but please let me know if you notice anything funky. Cheers!